### PR TITLE
Tweet for APAC sig-contribex meeting

### DIFF
--- a/tweets/24-09-2020-apac-contribex.tweet
+++ b/tweets/24-09-2020-apac-contribex.tweet
@@ -1,0 +1,1 @@
+The biweekly APAC sig-contribex meeting is starting soon! at 10 AM IST, 9:30 PM PT. Make sure to join in: https://github.com/kubernetes/community/blob/master/sig-contributor-experience/role-handbooks/apac-coordinator.md


### PR DESCRIPTION
This is a tweet request for shoutout to APAC sig-contribex meeting.

/hold

cc: @chris-short @kaslin 