### PR TITLE
Continuing contributor marketing

### DIFF
--- a/tweets/12-8-2020-contributor-celebration.tweet
+++ b/tweets/12-8-2020-contributor-celebration.tweet
@@ -1,0 +1,4 @@
+This Friday is the Kubernetes Contributor Celebration! Block your calendar and play games with your cloud native friends. Contributors from all related projects are welcome. 
+
+RTs appreciated!
+https://k8s.dev/celebration


### PR DESCRIPTION
A simple celebration tweet. Note that the URL should render and not show up at the bottom.

/assign @castrojo 
