### PR TITLE
feat: add automation scripts for the tweet action

### DIFF
--- a/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
+++ b/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Provide the actual tweet content below**
-<!-- Input your tweet content exactly below the commented colons -->
+<!-- Input your tweet content exactly between the commented colons -->
 <!--::-->
 
 <!--::-->

--- a/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
+++ b/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
@@ -2,12 +2,12 @@
 name: New tweet request
 about: Create a new tweet request
 title: "[Please change the title]"
-labels: ''
+labels: tweet
 assignees: ''
 
 ---
 
-**Provide the actual tweet content below**
+**Provide the actual tweet content between the commented colons**
 <!-- Input your tweet content exactly between the commented colons -->
 <!--::-->
 

--- a/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
+++ b/.github/assets/ISSUE_TEMPLATE/new-tweet-request.md
@@ -1,0 +1,14 @@
+---
+name: New tweet request
+about: Create a new tweet request
+title: "[Please change the title]"
+labels: ''
+assignees: ''
+
+---
+
+**Provide the actual tweet content below**
+<!-- Input your tweet content exactly below the commented colons -->
+<!--::-->
+
+<!--::-->

--- a/.github/assets/template.md
+++ b/.github/assets/template.md
@@ -1,0 +1,8 @@
+This is preserved as a backup for the yet to be implemented feature: Scheduled tweets. Do not delete this.
+
+:warning: Not implemented feature. Please leave as it is.
+
+**Provide a human friendly time for the tweet to go out**
+<!-- Input the scheduled time in conventional UTC format as follows: "2020-10-04T16:02:00.000Z" format. Please use `new Date().toISOString()` in JavaScript to get the date format -->
+
+>Time:

--- a/.github/assets/template.md
+++ b/.github/assets/template.md
@@ -1,8 +1,0 @@
-This is preserved as a backup for the yet to be implemented feature: Scheduled tweets. Do not delete this.
-
-:warning: Not implemented feature. Please leave as it is.
-
-**Provide a human friendly time for the tweet to go out**
-<!-- Input the scheduled time in conventional UTC format as follows: "2020-10-04T16:02:00.000Z" format. Please use `new Date().toISOString()` in JavaScript to get the date format -->
-
->Time:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,73 @@
+name: Parse and create PR
+on:
+  issues:
+    types: ['opened']
+  issue_comment:
+    types: ['created']
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  parse-issue-and-create-pr:
+    if: github.event_name != 'push' && github.event_name != 'pull_request' && github.event_name != 'issue_comment' || contains(github.event.comment.body, '/validate') && (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    name: Parse issue, validate timestamp and commit into tweets folder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+          check-latest: true
+      - run: npm install
+      - name: parsing from body of the issue
+        uses: ./
+        id: parseissue
+        with:
+          starting-parse-symbol: '<!--::-->'
+          file-name-extension: 'tweet'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Pull Request
+        if: steps.parseissue.outputs.continue-workflow == 'true'
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Add new tweet file via automation
+          title: 'add: new tweet file via automation'
+          body: |
+            This PR is auto-generated.
+            Fixes: #${{ steps.parseissue.outputs.issueNumber}}
+            /cc @${{ github.actor }}
+          labels: add, automated pr
+          branch: add/${{ steps.parseissue.outputs.issueNumber}}
+          base: main
+          signoff: true
+          delete-branch: true
+
+  preview:
+    name: Preview
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: gr2m/twitter-together@v1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  tweet:
+    name: Tweet
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: checkout main
+        uses: actions/checkout@v2
+      - name: Tweet
+        uses: gr2m/twitter-together@v1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+          TWITTER_API_SECRET_KEY: ${{ secrets.TWITTER_API_SECRET_KEY }}

--- a/.github/workflows/twitter-together.yaml
+++ b/.github/workflows/twitter-together.yaml
@@ -1,26 +1,26 @@
-on: [push, pull_request]
-name: Twitter, together!
-jobs:
-  preview:
-    name: Preview
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: gr2m/twitter-together@v1.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  tweet:
-    name: Tweet
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    steps:
-      - name: checkout master
-        uses: actions/checkout@v2
-      - name: Tweet
-        uses: gr2m/twitter-together@v1.x
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-          TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
-          TWITTER_API_SECRET_KEY: ${{ secrets.TWITTER_API_SECRET_KEY }}
+# on: [push, pull_request]
+# name: Twitter, together!
+# jobs:
+#   preview:
+#     name: Preview
+#     runs-on: ubuntu-latest
+#     if: github.event_name == 'pull_request'
+#     steps:
+#       - uses: gr2m/twitter-together@v1.x
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#   tweet:
+#     name: Tweet
+#     runs-on: ubuntu-latest
+#     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+#     steps:
+#       - name: checkout master
+#         uses: actions/checkout@v2
+#       - name: Tweet
+#         uses: gr2m/twitter-together@v1.x
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+#           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+#           TWITTER_API_KEY: ${{ secrets.TWITTER_API_KEY }}
+#           TWITTER_API_SECRET_KEY: ${{ secrets.TWITTER_API_SECRET_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,9 @@
 
 approvers:
   - chris-short
+  - gkarthiks
   - kaslin
   - mbbroberg
   - parispittman
   - Pensu
   - rajula96reddy
-  - gkarthiks

--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - parispittman
   - Pensu
   - rajula96reddy
+  - gkarthiks

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ Thanks to the team behind **twitter-together** for putting together a wonderful 
 
 ## Posting a new tweet
 
-1. Fork this repository
-2. Create a new `.tweet` file with the tweet contents. Make sure the file is as per the [guidelines](GUIDELINES.md)
-3. Create a PR to this repository
-4. Once the PR is approved and merged, the tweet is sent out from the [K8sContributors account](https://twitter.com/k8scontributors)
+1. Create a [new issue](https://github.com/kubernetes-sigs/contributor-tweets/issues/new/choose) in this reopository.
+2. Follow the issue template and fill in the prompts.
+3. Click submit.
+4. If you have exceeded the maximum length, you will be thrown with an error comment. Please fix and comment `/validate` on the issue to restart the automation process.
+5. If everything is fine, you will be given a pull request link in the issue.
+6. Once the PR is approved and merged, the tweet is sent out from the [K8sContributors account](https://twitter.com/k8scontributors)
 
 
 ## Notes

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,32 @@
+name: 'Contributor Tweet Test'
+description: 'Parses the isssue and creates a PR'
+inputs:
+  starting-parse-symbol:
+    description: 'The parsing symbol that specifies the start of the parsing characters.'
+    required: true
+    default: '<!--::-->'
+  path-to-save:
+    description: 'The path of the files that needs to be saved.'
+    required: true
+    default: "./tweets"
+  file-name-format:
+    description: 'The file name format that needs to be stored as'
+    required: true
+    default: "dd-mm-yyyy-hh-MM"
+  file-name-extension:
+    description: "The extension that needs to be used for the tweet file."
+    required: true
+    default: "tweet"
+  token:
+    description: Github token for octokit to comment back in the issue.
+    required: true
+  tweet-length:
+    description: Tweet length.
+    required: false
+    default: '280'
+outputs:
+  continue-workflow:
+    description: Binary value determines whether the flow should continue or skip.
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,10 @@
 name: 'Contributor Tweet Test'
 description: 'Parses the isssue and creates a PR'
 inputs:
+  tweet-label-id:
+    description: 'Label to be used in the issue to consider for a tweet.'
+    required: true
+    default: 'tweet'
   starting-parse-symbol:
     description: 'The parsing symbol that specifies the start of the parsing characters.'
     required: true

--- a/index.js
+++ b/index.js
@@ -28,128 +28,137 @@ Date.prototype.mmddyyyy = function() {
 };
 
 try {
-    
     var eventName = github.context.eventName
-    
     core.info("Current run happened for the following trigger: "+eventName)
 
     if (eventName.startsWith("issue")) {
 
-        // Extract and create the necessary variables and values
-        // sort of initialiazition part
-        var startingParseSymbol = core.getInput("starting-parse-symbol").trim();
-        var fileNameFormat = core.getInput("file-name-format").trim();
-        var pathToSave = core.getInput("path-to-save").trim();
-        var fileNameExtension = core.getInput("file-name-extension").trim();
-        var githubToken = core.getInput('token');
-        var tweetLength = core.getInput('tweet-length');
-        
-        var issueContext = github.context.payload.issue.body;
-        var issueNumber = github.context.payload.issue.number;
-        var issueTitle = github.context.payload.issue.title;
+        // Extract the label identifier in issues that needs a tweet ci run
+        var tweetLabelId = core.getInput("tweet-label-id").trim();
+        var issueLabel = "\""+tweetLabelId+"\""
 
-        var parseSymbolFirstIndex = issueContext.indexOf(startingParseSymbol)
+        // Validate and continue if the issue is opened for a tweet
+        var strLabels = JSON.stringify(github.context.payload.issue.labels)
+        if (strLabels.includes(issueLabel)) {    
+            // Extract and create the necessary variables and values
+            // sort of initialiazition part
+            var startingParseSymbol = core.getInput("starting-parse-symbol").trim();
+            var fileNameFormat = core.getInput("file-name-format").trim();
+            var pathToSave = core.getInput("path-to-save").trim();
+            var fileNameExtension = core.getInput("file-name-extension").trim();
+            var githubToken = core.getInput('token');
+            var tweetLength = core.getInput('tweet-length');
+            
+            var issueContext = github.context.payload.issue.body;
+            var issueNumber = github.context.payload.issue.number;
+            var issueTitle = github.context.payload.issue.title;
 
-        core.info(`The parsing symbol first found @ ${parseSymbolFirstIndex}`)
+            var parseSymbolFirstIndex = issueContext.indexOf(startingParseSymbol)
 
-        if (parseSymbolFirstIndex < 0 ) {        
-            core.info("The issue "+issueNumber+" is not for creation of new tweet.")
-            core.info("Setting the continue-workflow to false.")
-            core.setOutput("continue-workflow", false)
-            exit(0)
-        }
+            core.info(`The parsing symbol first found @ ${parseSymbolFirstIndex}`)
 
-        var parseSymbolLastIndex = issueContext.lastIndexOf(startingParseSymbol)
-        var tweetContent = issueContext.substring(parseSymbolFirstIndex + startingParseSymbol.length, parseSymbolLastIndex);
-        var sanitizedTweetContent = tweetContent.replace( /[\r\n]+/gm, "" )
-
-        core.info(`
-        ===========================================================================
-        Tweet content:
-            ${sanitizedTweetContent}
-        ===========================================================================
-        `)
-
-        if (sanitizedTweetContent.length > 0)  {
-            core.info("Setting the contibue-workflow to TRUE.")
-            core.setOutput("continue-workflow", true)
-        } else {
-            core.info("The issue "+issueNumber+" is not for creation of new tweet.")
-            core.info("Setting the continue-workflow to false.")
-            core.setOutput("continue-workflow", false)
-            exit(0)
-        }
-
-        // TBD: uncomment when scheduled time is enabled.
-        // var tweetScheduleTime = issueContext.substring(issueContext.indexOf("Time:")+5, issueContext.length).trim();
-
-        var fileNameDate, completeFileName;
-        var issueTitle30Chars = issueTitle.substring(0,30);
-        var sanitizedIssueTitle = issueTitle30Chars.replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1);
-
-        // Validate the given timestamp is valid time and return null, 
-        // if not valid, throws an error and exits.
-        // TBD: uncomment when scheduled time is enabled.
-        // validateTimestamp(tweetScheduleTime, githubToken)
-
-        // Validates the length of the tweet content
-        if (sanitizedTweetContent.length > tweetLength) {
-            commentToIssue(
-                "Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet and comment /validate to trigger the workflow again.",
-                githubToken
-            )
-            core.setFailed("Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet.")
-            core.info("Setting the continue-workflow to false.")
-            core.setOutput("continue-workflow", false)
-        } else {
-            core.info(`The tweet content is ${sanitizedTweetContent}`);
-
-            // Creates the new file to be committed into the repo.
-            if (!fs.existsSync(pathToSave)){
-                fs.mkdirSync(pathToSave, { recursive: true });
+            if (parseSymbolFirstIndex < 0 ) {        
+                core.info("The issue "+issueNumber+" is not for creation of new tweet.")
+                core.info("Setting the continue-workflow to false.")
+                core.setOutput("continue-workflow", false)
+                exit(0)
             }
-        
-            core.info(`    
-                The symbol declared for parsing is ${startingParseSymbol}
-                The file name format is specified as ${fileNameFormat}
-                The file name extension is specified as ${fileNameExtension}
-                The path to save the file is specified as ${pathToSave}
-                Sanitized issue title is ${sanitizedIssueTitle}
 
-            `);
-            // TBD: uncomment when scheduled time is enabled and move into the brace above.
-            // Scheduled tweet time is ${tweetScheduleTime}
-            // TBD: remove the below assignment to tweetScheduleTime
-            var tweetScheduleTime = ""
-            if (tweetScheduleTime === "") {
-                core.info("Scheduled time is null, creating the file name with the specified format.")
-                var date = new Date();
-                if (fileNameFormat === "dd-mm-yyyy-hh-MM") {
-                    fileNameDate = date.ddmmyyyy();
-                } else if (fileNameFormat === "mm-dd-yyyy-hh-MM") {
-                    fileNameDate = date.mmddyyyy();
-                }
-                completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
-                core.info(`File name to be saved as ${completeFileName}`)
+            var parseSymbolLastIndex = issueContext.lastIndexOf(startingParseSymbol)
+            var tweetContent = issueContext.substring(parseSymbolFirstIndex + startingParseSymbol.length, parseSymbolLastIndex);
+            var sanitizedTweetContent = tweetContent.replace( /[\r\n]+/gm, "" )
+
+            core.info(`
+            ===========================================================================
+            Tweet content:
+                ${sanitizedTweetContent}
+            ===========================================================================
+            `)
+
+            if (sanitizedTweetContent.length > 0)  {
+                core.info("Setting the contibue-workflow to TRUE.")
+                core.setOutput("continue-workflow", true)
             } else {
-                fileNameDate = new Date(tweetScheduleTime).toJSON().replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1)
-                completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
-                core.info(`File name to be saved as ${completeFileName}`)
+                core.info("The issue "+issueNumber+" is not for creation of new tweet.")
+                core.info("Setting the continue-workflow to false.")
+                core.setOutput("continue-workflow", false)
+                exit(0)
             }
-            const dataFilePath = pathToSave+'/'+completeFileName;
-            fs.writeFile(dataFilePath, sanitizedTweetContent, (err) => {
-                if (err) throw err;
-            });
-        
-            core.info("Parsing done, commenting on issue.")
-        
-            commentToIssue(
-                "A new file has been created with your tweet content. Please refer the below linked PR",
-                githubToken
-            )    
+
+            // TBD: uncomment when scheduled time is enabled.
+            // var tweetScheduleTime = issueContext.substring(issueContext.indexOf("Time:")+5, issueContext.length).trim();
+
+            var fileNameDate, completeFileName;
+            var issueTitle30Chars = issueTitle.substring(0,30);
+            var sanitizedIssueTitle = issueTitle30Chars.replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1);
+
+            // Validate the given timestamp is valid time and return null, 
+            // if not valid, throws an error and exits.
+            // TBD: uncomment when scheduled time is enabled.
+            // validateTimestamp(tweetScheduleTime, githubToken)
+
+            // Validates the length of the tweet content
+            if (sanitizedTweetContent.length > tweetLength) {
+                commentToIssue(
+                    "Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet and comment /validate to trigger the workflow again.",
+                    githubToken
+                )
+                core.setFailed("Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet.")
+                core.info("Setting the continue-workflow to false.")
+                core.setOutput("continue-workflow", false)
+            } else {
+                core.info(`The tweet content is ${sanitizedTweetContent}`);
+
+                // Creates the new file to be committed into the repo.
+                if (!fs.existsSync(pathToSave)){
+                    fs.mkdirSync(pathToSave, { recursive: true });
+                }
+            
+                core.info(`    
+                    The symbol declared for parsing is ${startingParseSymbol}
+                    The file name format is specified as ${fileNameFormat}
+                    The file name extension is specified as ${fileNameExtension}
+                    The path to save the file is specified as ${pathToSave}
+                    Sanitized issue title is ${sanitizedIssueTitle}
+
+                `);
+
+                // TBD: uncomment when scheduled time is enabled and move into the brace above.
+                // Scheduled tweet time is ${tweetScheduleTime}
+                // TBD: remove the below assignment to tweetScheduleTime
+                var tweetScheduleTime = ""
+                if (tweetScheduleTime === "") {
+                    core.info("Scheduled time is null, creating the file name with the specified format.")
+                    var date = new Date();
+                    if (fileNameFormat === "dd-mm-yyyy-hh-MM") {
+                        fileNameDate = date.ddmmyyyy();
+                    } else if (fileNameFormat === "mm-dd-yyyy-hh-MM") {
+                        fileNameDate = date.mmddyyyy();
+                    }
+                    completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
+                    core.info(`File name to be saved as ${completeFileName}`)
+                } else {
+                    fileNameDate = new Date(tweetScheduleTime).toJSON().replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1)
+                    completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
+                    core.info(`File name to be saved as ${completeFileName}`)
+                }
+                const dataFilePath = pathToSave+'/'+completeFileName;
+                fs.writeFile(dataFilePath, sanitizedTweetContent, (err) => {
+                    if (err) throw err;
+                });
+            
+                core.info("Parsing done, commenting on issue.")
+            
+                commentToIssue(
+                    "A new file has been created with your tweet content. Please refer the below linked PR",
+                    githubToken
+                )    
+            }
+
+            core.setOutput("issueNumber", issueNumber);
+            console.log("yes")
         }
 
-        core.setOutput("issueNumber", issueNumber);
     } else if (eventName.startsWith("pull_request")) {
         core.info("TBD: Pull Request job")
     }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const core = require('@actions/core');
 const github = require('@actions/github');
 const fs = require('fs');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,184 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const fs = require('fs');
+const { exit } = require('process');
+
+Date.prototype.ddmmyyyy = function() {
+    var mm = this.getMonth() + 1;
+    var dd = this.getDate();
+  
+    return [(dd>9 ? '' : '0') + dd,
+            (mm>9 ? '' : '0') + mm,
+            this.getFullYear(),
+            this.getUTCHours(),
+            this.getUTCMinutes()
+           ].join('-');
+};
+
+Date.prototype.mmddyyyy = function() {
+    var mm = this.getMonth() + 1;
+    var dd = this.getDate();
+  
+    return [(mm>9 ? '' : '0') + mm,
+            (dd>9 ? '' : '0') + dd,
+            this.getFullYear(),
+            this.getUTCHours(),
+            this.getUTCMinutes()
+           ].join('-');
+};
+
+try {
+    
+    var eventName = github.context.eventName
+    
+    core.info("Current run happened for the following trigger: "+eventName)
+
+    if (eventName.startsWith("issue")) {
+
+        // Extract and create the necessary variables and values
+        // sort of initialiazition part
+        var startingParseSymbol = core.getInput("starting-parse-symbol").trim();
+        var fileNameFormat = core.getInput("file-name-format").trim();
+        var pathToSave = core.getInput("path-to-save").trim();
+        var fileNameExtension = core.getInput("file-name-extension").trim();
+        var githubToken = core.getInput('token');
+        var tweetLength = core.getInput('tweet-length');
+        
+        var issueContext = github.context.payload.issue.body;
+        var issueNumber = github.context.payload.issue.number;
+        var issueTitle = github.context.payload.issue.title;
+
+        var parseSymbolFirstIndex = issueContext.indexOf(startingParseSymbol)
+
+        core.info(`The parsing symbol first found @ ${parseSymbolFirstIndex}`)
+
+        if (parseSymbolFirstIndex < 0 ) {        
+            core.info("The issue "+issueNumber+" is not for creation of new tweet.")
+            core.info("Setting the continue-workflow to false.")
+            core.setOutput("continue-workflow", false)
+            exit(0)
+        }
+
+        var parseSymbolLastIndex = issueContext.lastIndexOf(startingParseSymbol)
+        var tweetContent = issueContext.substring(parseSymbolFirstIndex + startingParseSymbol.length, parseSymbolLastIndex);
+        var sanitizedTweetContent = tweetContent.replace( /[\r\n]+/gm, "" )
+
+        core.info(`
+        ===========================================================================
+        Tweet content:
+            ${sanitizedTweetContent}
+        ===========================================================================
+        `)
+
+        if (sanitizedTweetContent.length > 0)  {
+            core.info("Setting the contibue-workflow to TRUE.")
+            core.setOutput("continue-workflow", true)
+        } else {
+            core.info("The issue "+issueNumber+" is not for creation of new tweet.")
+            core.info("Setting the continue-workflow to false.")
+            core.setOutput("continue-workflow", false)
+            exit(0)
+        }
+
+        // TBD: uncomment when scheduled time is enabled.
+        // var tweetScheduleTime = issueContext.substring(issueContext.indexOf("Time:")+5, issueContext.length).trim();
+
+        var fileNameDate, completeFileName;
+        var issueTitle30Chars = issueTitle.substring(0,30);
+        var sanitizedIssueTitle = issueTitle30Chars.replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1);
+
+        // Validate the given timestamp is valid time and return null, 
+        // if not valid, throws an error and exits.
+        // TBD: uncomment when scheduled time is enabled.
+        // validateTimestamp(tweetScheduleTime, githubToken)
+
+        // Validates the length of the tweet content
+        if (sanitizedTweetContent.length > tweetLength) {
+            commentToIssue(
+                "Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet and comment /validate to trigger the workflow again.",
+                githubToken
+            )
+            core.setFailed("Tweet content length is exceeding the permitted tweet length. Please rephrase the tweet.")
+            core.info("Setting the continue-workflow to false.")
+            core.setOutput("continue-workflow", false)
+        } else {
+            core.info(`The tweet content is ${sanitizedTweetContent}`);
+
+            // Creates the new file to be committed into the repo.
+            if (!fs.existsSync(pathToSave)){
+                fs.mkdirSync(pathToSave, { recursive: true });
+            }
+        
+            core.info(`    
+                The symbol declared for parsing is ${startingParseSymbol}
+                The file name format is specified as ${fileNameFormat}
+                The file name extension is specified as ${fileNameExtension}
+                The path to save the file is specified as ${pathToSave}
+                Sanitized issue title is ${sanitizedIssueTitle}
+
+            `);
+            // TBD: uncomment when scheduled time is enabled and move into the brace above.
+            // Scheduled tweet time is ${tweetScheduleTime}
+            // TBD: remove the below assignment to tweetScheduleTime
+            var tweetScheduleTime = ""
+            if (tweetScheduleTime === "") {
+                core.info("Scheduled time is null, creating the file name with the specified format.")
+                var date = new Date();
+                if (fileNameFormat === "dd-mm-yyyy-hh-MM") {
+                    fileNameDate = date.ddmmyyyy();
+                } else if (fileNameFormat === "mm-dd-yyyy-hh-MM") {
+                    fileNameDate = date.mmddyyyy();
+                }
+                completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
+                core.info(`File name to be saved as ${completeFileName}`)
+            } else {
+                fileNameDate = new Date(tweetScheduleTime).toJSON().replace(/[^a-zA-Z0-9]/g,'-').trim().slice(0, -1)
+                completeFileName = fileNameDate+sanitizedIssueTitle+"."+fileNameExtension
+                core.info(`File name to be saved as ${completeFileName}`)
+            }
+            const dataFilePath = pathToSave+'/'+completeFileName;
+            fs.writeFile(dataFilePath, sanitizedTweetContent, (err) => {
+                if (err) throw err;
+            });
+        
+            core.info("Parsing done, commenting on issue.")
+        
+            commentToIssue(
+                "A new file has been created with your tweet content. Please refer the below linked PR",
+                githubToken
+            )    
+        }
+
+        core.setOutput("issueNumber", issueNumber);
+    } else if (eventName.startsWith("pull_request")) {
+        core.info("TBD: Pull Request job")
+    }
+} catch (error) {
+    core.setFailed(error.message);
+}
+
+// Validates the provided time is valid time format
+function validateTimestamp(tweetScheduleTime, githubToken) {
+    if (tweetScheduleTime !== "") {
+        var parsedTime = Date.parse(tweetScheduleTime);
+        if (isNaN(parsedTime)) {
+            commentToIssue(
+                "Specified time is not a valid UTC timestamp for the tweet schedule. Please verify and comment /validate to trigger the workflow again",
+                githubToken
+            )
+            core.setFailed("Error occured while parsing the given timestamp. Please provide the time in conventional UTC format as 2020-10-04T16:02:11.029Z")
+            core.error("Error occured while parsing the given timestamp. Please provide the time in conventional UTC format as 2020-10-04T16:02:11.029Z")
+        }
+    }
+}
+
+
+// Commenting back to issue with provided message
+function commentToIssue(body, githubToken) {
+    github.getOctokit(githubToken).issues.createComment({
+        issue_number: github.context.issue.number,
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        body: body
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,171 @@
+{
+  "name": "contributor-tweets-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
+    },
+    "@actions/github": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-4.0.0.tgz",
+      "integrity": "sha512-Ej/Y2E+VV6sR9X7pWL5F3VgEWrABaT292DRqRU6R4hnQjPtC/zD3nagxVdXWiRQvYDh8kHXo7IDmG42eJ/dOMA==",
+      "requires": {
+        "@actions/http-client": "^1.0.8",
+        "@octokit/core": "^3.0.0",
+        "@octokit/plugin-paginate-rest": "^2.2.3",
+        "@octokit/plugin-rest-endpoint-methods": "^4.0.0"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
+      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+      "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/graphql": "^4.3.1",
+        "@octokit/request": "^5.4.0",
+        "@octokit/types": "^5.0.0",
+        "before-after-hook": "^2.1.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+      "integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
+      "requires": {
+        "@octokit/types": "^5.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+      "integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+      "integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
+      "requires": {
+        "@octokit/types": "^5.5.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz",
+      "integrity": "sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==",
+      "requires": {
+        "@octokit/types": "^5.5.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.9",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+      "integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^5.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+      "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+      "requires": {
+        "@octokit/types": "^5.0.1",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+      "integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "name": "contributor-tweets-test",
   "version": "1.0.0",
-  "description": "K8s Contributor Tweet testing repo",
+  "description": "K8s Contributor Tweet Automation repo",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gkarthiks/contributor-tweets-test.git"
+    "url": "git+https://github.com/kubernetes-sigs/contributor-tweets.git"
   },
   "author": "Karthikeyan Govindaraj <github.gkarthiks@gmail.com>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/gkarthiks/contributor-tweets-test/issues"
+    "url": "https://github.com/kubernetes-sigs/contributor-tweets/issues"
   },
-  "homepage": "https://github.com/gkarthiks/contributor-tweets-test#readme",
+  "homepage": "https://github.com/kubernetes-sigs/contributor-tweets#readme",
   "dependencies": {
     "@actions/core": "^1.2.5",
     "@actions/github": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "contributor-tweets-test",
+  "version": "1.0.0",
+  "description": "K8s Contributor Tweet testing repo",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gkarthiks/contributor-tweets-test.git"
+  },
+  "author": "Karthikeyan Govindaraj <github.gkarthiks@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/gkarthiks/contributor-tweets-test/issues"
+  },
+  "homepage": "https://github.com/gkarthiks/contributor-tweets-test#readme",
+  "dependencies": {
+    "@actions/core": "^1.2.5",
+    "@actions/github": "^4.0.0"
+  }
+}


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

## Current Scenario:
To send a new tweet, a user needs to fork this repo and create a new `.tweet` file and create a PR. Once the PR is approved, the content will be tweeted.

## Feature Addition:
This PR will add the semi-automation action for creating the tweet file from an issue. 

To create the tweet, a user just needs to create an issue. The in-built custom action will validate the content and creates PR with the new `.tweet` file. The PR number will be linked to the issue automatically. 

Now once the PR is approved, the legacy process follows for the auto-tweet. The functionality is mimicked in the testing repo and the video file link is furnished beneath.

https://drive.google.com/file/d/1ilN3ntMNUR-u_4p3LZhNLOVXsQB1dk6K/view?usp=sharing