### PR TITLE
Upcoming removals

### DIFF
--- a/tweets/2021-02-09-upcoming-removals.tweet
+++ b/tweets/2021-02-09-upcoming-removals.tweet
@@ -1,0 +1,1 @@
+In version 1.22, several v1beta1 API objects will be removed in favor of their v1 API versions. CustomResourceDefinition, MutatingWebhookConfiguration, and ValidatingWebhookConfiguration will only be available the v1 APIs, rather than the v1beta1 API. https://groups.google.com/g/kubernetes-dev/c/z_AE1EHhZF4/m/fwHC6KSjAwAJ


### PR DESCRIPTION
Creating a tweet to promote awareness of v1beta1 API object removals. The stated API objects will *only* be available in the v1 API starting in 1.22. Links to the k-dev thread with more information.

cc: @mbbroberg

Wording suggestions/fixes welcome of course.

There will be several tweets, so putting a hold on this so we can select when to tweet.
/hold