### PR TITLE
Fix tweet action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
   tweet:
     name: Tweet
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
-      - name: checkout main
+      - name: checkout master
         uses: actions/checkout@v2
       - name: Tweet
         uses: gr2m/twitter-together@v1.x


### PR DESCRIPTION
This is a fix on top of changes from https://github.com/kubernetes-sigs/contributor-tweets/pull/43 and https://github.com/kubernetes-sigs/contributor-tweets/pull/33

The migration from `master` to `main` is tracked in a new [issue](https://github.com/kubernetes-sigs/contributor-tweets/issues/46) and will be fixed in a new PR