### PR TITLE
fix: move label to kind/tweet

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-tweet-request.md
+++ b/.github/ISSUE_TEMPLATE/new-tweet-request.md
@@ -2,7 +2,7 @@
 name: New tweet request
 about: Create a new tweet request
 title: "[Please change the title]"
-labels: tweet
+labels: kind/tweet
 assignees: ''
 
 ---

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Add new tweet file via automation
           title: 'add: new tweet file via automation'
-          tweet-label-id: 'tweet'
+          tweet-label-id: 'kind/tweet'
           body: |
             This PR is auto-generated.
             Fixes: #${{ steps.parseissue.outputs.issueNumber}}


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

Ref: https://github.com/kubernetes-sigs/contributor-tweets/issues/49#issuecomment-876308368

Moving the expectation of the action on the label from `tweet` to `kind/tweet` and making the label default with the issue templates.

/cc @rajula96reddy 