### PR TITLE
fix: default label set

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,7 @@ inputs:
   tweet-label-id:
     description: 'Label to be used in the issue to consider for a tweet.'
     required: true
-    default: 'tweet'
+    default: 'kind/tweet'
   starting-parse-symbol:
     description: 'The parsing symbol that specifies the start of the parsing characters.'
     required: true


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

Fixing the default label in the source action. Hoping to be the final change for the automation.