### PR TITLE
chore: migrate to main as the default branch in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
       - "*"
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   parse-issue-and-create-pr:
@@ -45,7 +45,7 @@ jobs:
             /cc @${{ github.actor }}
           labels: add, automated pr
           branch: add/${{ steps.parseissue.outputs.issueNumber}}
-          base: master
+          base: main
           signoff: true
           delete-branch: true
 
@@ -60,9 +60,9 @@ jobs:
   tweet:
     name: Tweet
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - name: checkout master
+      - name: checkout main
         uses: actions/checkout@v2
       - name: Tweet
         uses: gr2m/twitter-together@v1.x


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

This PR will make the GitHub Actions consider `main` as the default branch.

Ref: https://github.com/kubernetes-sigs/contributor-tweets/issues/46

/cc @chris-short 