### PR TITLE
changed the marketing-team subdirectory name to contributor-comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to Contributor Tweets!
 
 This repository is part of the automation, to tweet from the [K8sContributors](https://twitter.com/k8scontributors) twitter account. If you are looking at posting a tweet from the K8sContributors account, please follow the [instructions](#posting-a-new-tweet) below.
 
-This project is currently owned and maintained by the [SIG Contribex Marketing Team](https://github.com/kubernetes/community/tree/master/communication/marketing-team).
+This project is currently owned and maintained by the [SIG Contribex Marketing Team](https://github.com/kubernetes/community/tree/master/communication/contributor-comms).
 
 ## Automation
 


### PR DESCRIPTION
Part of https://github.com/kubernetes/community/issues/6641(https://github.com/kubernetes/community/issues?q=is%3Aopen+is%3Aissue+assignee%3Aharshitasao+label%3Aarea%2Fcontributor-comms) 